### PR TITLE
refactor: change format date function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/iceber/iouring-go v0.0.0-20220609112130-b1dc8dd9fbfd
 	github.com/jedib0t/go-pretty/v6 v6.3.1
 	github.com/json-iterator/go v1.1.12
+	github.com/labstack/gommon v0.4.0
 	github.com/linkall-labs/embed-etcd v0.1.1
 	github.com/linkall-labs/vanus/client v0.5.1
 	github.com/linkall-labs/vanus/observability v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/labstack/gommon v0.4.0 h1:y7cvthEAEbU0yHOf4axH8ZG2NH8knB9iNSoTO8dyIk8=
+github.com/labstack/gommon v0.4.0/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
 github.com/linkall-labs/embed-etcd v0.1.1 h1:WxV9wbnRtNf7DMW8SJauVYqhFLXzRfY5wpplFypXK9k=
 github.com/linkall-labs/embed-etcd v0.1.1/go.mod h1:dmleSy0Myllw6W5awwjyDMipgICVDHTHuTcRT4cqaIc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -413,6 +415,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1 h1:VOMT+81stJgXW3CpHyqHN3AXDYIMsx56mEFrB37Mb/E=
@@ -636,6 +639,7 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/primitive/transform/action/action.go
+++ b/internal/primitive/transform/action/action.go
@@ -18,12 +18,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/linkall-labs/vanus/internal/primitive/transform/context"
-
-	"github.com/pkg/errors"
-
 	"github.com/linkall-labs/vanus/internal/primitive/transform/arg"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/context"
 	"github.com/linkall-labs/vanus/internal/primitive/transform/function"
+	"github.com/pkg/errors"
 )
 
 type newAction func() Action
@@ -170,8 +168,8 @@ func init() {
 		newMathMulActionAction,
 		newMathDivActionAction,
 		// format
-		newFormatDateAction,
-		newFormatUnixTimeAction,
+		newDateFormatAction,
+		newUnixTimeFormatAction,
 		// string
 		newJoinAction,
 		newUpperAction,

--- a/internal/primitive/transform/action/action_bench_test.go
+++ b/internal/primitive/transform/action/action_bench_test.go
@@ -56,7 +56,7 @@ func newEventContext(event ce.Event) *context.EventContext {
 			"str":    "dataStr",
 			"number": 456.654,
 			"second": float64(1669120748),
-			"time":   "2022/11/22 20:40:30",
+			"time":   "2022-11-22T20:40:30Z",
 		},
 	}
 }
@@ -71,8 +71,8 @@ func BenchmarkAction(b *testing.B) {
 	b.Run("math_sub", actionBenchmark([]interface{}{"math_sub", "$.data.math_sub", "$.data.number", "<number>"}))
 	b.Run("math_mul", actionBenchmark([]interface{}{"math_mul", "$.data.math_mul", "$.data.number", "<number>"}))
 	b.Run("math_div", actionBenchmark([]interface{}{"math_div", "$.data.math_div", "$.data.number", "<number>"}))
-	b.Run("format_unix_time", actionBenchmark([]interface{}{"format_unix_time", "$.data.second", "yyyy-mm-dd HH:MM:SS"}))
-	b.Run("format_date", actionBenchmark([]interface{}{"format_date", "$.data.time", "yyyy/mm/dd HH:MM:SS", "yyyy-mm-dd HH:MM:SS"}))
+	b.Run("unix_time_format", actionBenchmark([]interface{}{"unix_time_format", "$.data.second", "Y-m-d H:i:s"}))
+	b.Run("date_format", actionBenchmark([]interface{}{"date_format", "$.data.time", "Y-m-d H:i:s"}))
 	b.Run("join", actionBenchmark([]interface{}{"join", "$.data.join", ",", "$.data.str", "<str>"}))
 	b.Run("upper_case", actionBenchmark([]interface{}{"upper_case", "$.data.str"}))
 	b.Run("lower_case", actionBenchmark([]interface{}{"lower_case", "$.data.str"}))

--- a/internal/primitive/transform/action/math_action_test.go
+++ b/internal/primitive/transform/action/math_action_test.go
@@ -18,11 +18,10 @@ import (
 	"testing"
 
 	"github.com/linkall-labs/vanus/internal/primitive/transform/context"
-
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestMathAction(t *testing.T) {
+func TestMathAddAction(t *testing.T) {
 	Convey("test math add", t, func() {
 		a, err := NewAction([]interface{}{newMathAddActionAction().Name(), "$.test", "123", "456", "321"})
 		So(err, ShouldBeNil)
@@ -33,6 +32,9 @@ func TestMathAction(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(e.Extensions()["test"], ShouldEqual, int32(900))
 	})
+}
+
+func TestMathSubAction(t *testing.T) {
 	Convey("test math sub", t, func() {
 		a, err := NewAction([]interface{}{newMathSubActionAction().Name(), "$.test", "456", "123"})
 		So(err, ShouldBeNil)
@@ -43,6 +45,9 @@ func TestMathAction(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(e.Extensions()["test"], ShouldEqual, int32(333))
 	})
+}
+
+func TestMathMulAction(t *testing.T) {
 	Convey("test math mul", t, func() {
 		a, err := NewAction([]interface{}{newMathMulActionAction().Name(), "$.test", "111", "2", "3"})
 		So(err, ShouldBeNil)
@@ -53,6 +58,9 @@ func TestMathAction(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(e.Extensions()["test"], ShouldEqual, int32(666))
 	})
+}
+
+func TestMathDivAction(t *testing.T) {
 	Convey("test math div", t, func() {
 		Convey("div zero", func() {
 			a, err := NewAction([]interface{}{newMathDivActionAction().Name(), "$.test", "333", "0"})

--- a/internal/primitive/transform/action/regex_action_test.go
+++ b/internal/primitive/transform/action/regex_action_test.go
@@ -18,11 +18,10 @@ import (
 	"testing"
 
 	"github.com/linkall-labs/vanus/internal/primitive/transform/context"
-
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestRegexAction(t *testing.T) {
+func TestReplaceWithRegexAction(t *testing.T) {
 	Convey("test replace with regex", t, func() {
 		a, err := NewAction([]interface{}{newReplaceWithRegexAction().Name(), "$.test", "a", "value"})
 		So(err, ShouldBeNil)

--- a/internal/primitive/transform/action/string_action_test.go
+++ b/internal/primitive/transform/action/string_action_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestStringAction(t *testing.T) {
+func TestJoinAction(t *testing.T) {
 	Convey("test join action", t, func() {
 		eventCtx := &context.EventContext{
 			Event: newEvent(),
@@ -66,6 +66,9 @@ func TestStringAction(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestUpperAction(t *testing.T) {
 	Convey("test upper", t, func() {
 		a, err := NewAction([]interface{}{newUpperAction().Name(), "$.test"})
 		So(err, ShouldBeNil)
@@ -78,6 +81,9 @@ func TestStringAction(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(e.Extensions()["test"], ShouldEqual, "TESTVALUE")
 	})
+}
+
+func TestLowerAction(t *testing.T) {
 	Convey("test lower", t, func() {
 		a, err := NewAction([]interface{}{newLowerAction().Name(), "$.test"})
 		So(err, ShouldBeNil)
@@ -90,6 +96,9 @@ func TestStringAction(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(e.Extensions()["test"], ShouldEqual, "testvalue")
 	})
+}
+
+func TestAddPrefixAction(t *testing.T) {
 	Convey("test add prefix", t, func() {
 		a, err := NewAction([]interface{}{newAddPrefixAction().Name(), "$.test", "prefix"})
 		So(err, ShouldBeNil)
@@ -102,6 +111,9 @@ func TestStringAction(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(e.Extensions()["test"], ShouldEqual, "prefixtestValue")
 	})
+}
+
+func TestAddSuffixAction(t *testing.T) {
 	Convey("test add suffix", t, func() {
 		a, err := NewAction([]interface{}{newAddSuffixAction().Name(), "$.test", "suffix"})
 		So(err, ShouldBeNil)

--- a/internal/primitive/transform/action/struct_action_test.go
+++ b/internal/primitive/transform/action/struct_action_test.go
@@ -18,11 +18,10 @@ import (
 	"testing"
 
 	"github.com/linkall-labs/vanus/internal/primitive/transform/context"
-
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestStructAction(t *testing.T) {
+func TestDeleteAction(t *testing.T) {
 	Convey("test delete", t, func() {
 		Convey("delete cant not delete key", func() {
 			a, err := NewAction([]interface{}{newDeleteAction().Name(), "$.id"})
@@ -45,6 +44,9 @@ func TestStructAction(t *testing.T) {
 			So(len(e.Extensions()), ShouldEqual, 0)
 		})
 	})
+}
+
+func TestCreateAction(t *testing.T) {
 	Convey("test create", t, func() {
 		Convey("create exist key", func() {
 			a, err := NewAction([]interface{}{newCreateActionAction().Name(), "$.test", "newValue"})
@@ -76,6 +78,9 @@ func TestStructAction(t *testing.T) {
 			So(e.Extensions()["test"], ShouldEqual, "testValue")
 		})
 	})
+}
+
+func TestReplaceAction(t *testing.T) {
 	Convey("test replace", t, func() {
 		Convey("replace no exist key", func() {
 			a, err := NewAction([]interface{}{newReplaceAction().Name(), "$.test", "newValue"})
@@ -98,6 +103,9 @@ func TestStructAction(t *testing.T) {
 			So(e.Extensions()["test"], ShouldEqual, "testValue")
 		})
 	})
+}
+
+func TestMoveAction(t *testing.T) {
 	Convey("test move", t, func() {
 		Convey("move target key exist", func() {
 			a, err := NewAction([]interface{}{newMoveActionAction().Name(), "$.test", "$.data.abc.test"})
@@ -129,6 +137,9 @@ func TestStructAction(t *testing.T) {
 			So(ceCtx.Data.(map[string]interface{})["abc"].(map[string]interface{})["test"], ShouldEqual, "abc")
 		})
 	})
+}
+
+func TestRenameAction(t *testing.T) {
 	Convey("test rename", t, func() {
 		Convey("rename target key exist", func() {
 			a, err := NewAction([]interface{}{newRenameActionAction().Name(), "$.test", "$.test2"})

--- a/internal/primitive/transform/action/time_action.go
+++ b/internal/primitive/transform/action/time_action.go
@@ -19,22 +19,24 @@ import (
 	"github.com/linkall-labs/vanus/internal/primitive/transform/function"
 )
 
-// ["format_date", "key", "oldFormat","newFormat"].
-func newFormatDateAction() Action {
+// ["date_format", "key", "format"，"timeZone"].
+func newDateFormatAction() Action {
 	return &sourceTargetSameAction{
 		commonAction{
-			fixedArgs: []arg.TypeList{arg.EventList, arg.All, arg.All},
-			fn:        function.FormatDateFunction,
+			fixedArgs:   []arg.TypeList{arg.EventList, arg.All},
+			variadicArg: arg.All,
+			fn:          function.DateFormatFunction,
 		},
 	}
 }
 
-// ["format_unix_time", "key", "format"].
-func newFormatUnixTimeAction() Action {
+// ["unix_time_format", "key", "format","timeZone"].
+func newUnixTimeFormatAction() Action {
 	return &sourceTargetSameAction{
 		commonAction{
-			fixedArgs: []arg.TypeList{arg.EventList, arg.All},
-			fn:        function.FormatUnixTimeFunction,
+			fixedArgs:   []arg.TypeList{arg.EventList, arg.All},
+			variadicArg: arg.All,
+			fn:          function.UnixTimeFormatFunction,
 		},
 	}
 }

--- a/internal/primitive/transform/action/time_action_test.go
+++ b/internal/primitive/transform/action/time_action_test.go
@@ -31,27 +31,58 @@ func newEvent() *ce.Event {
 	return &e
 }
 
-func TestFormatAction(t *testing.T) {
+func TestDateFormatAction(t *testing.T) {
 	Convey("test format date", t, func() {
-		a, err := NewAction([]interface{}{newFormatDateAction().Name(), "$.test", "yyyy-mm-ddTHH:MM:SSZ", "yyyy-mm-dd HH:MM:SS"})
-		So(err, ShouldBeNil)
-		e := newEvent()
-		e.SetExtension("test", "2022-11-15T15:41:25Z")
-		err = a.Execute(&context.EventContext{
-			Event: e,
+		Convey("test default time zone", func() {
+			e := newEvent()
+			e.SetExtension("test", "2022-11-15T15:41:25Z")
+			a, err := NewAction([]interface{}{newDateFormatAction().Name(), "$.test", "Y-m-d H:i:s"})
+			So(err, ShouldBeNil)
+
+			err = a.Execute(&context.EventContext{
+				Event: e,
+			})
+			So(err, ShouldBeNil)
+			So(e.Extensions()["test"], ShouldEqual, "2022-11-15 15:41:25")
 		})
-		So(err, ShouldBeNil)
-		So(e.Extensions()["test"], ShouldEqual, "2022-11-15 15:41:25")
+		Convey("test with time zone", func() {
+			e := newEvent()
+			e.SetExtension("test", "2022-11-15T15:41:25Z")
+			a, err := NewAction([]interface{}{newDateFormatAction().Name(), "$.test", "Y-m-d H:i:s", "EST"})
+			So(err, ShouldBeNil)
+
+			err = a.Execute(&context.EventContext{
+				Event: e,
+			})
+			So(err, ShouldBeNil)
+			So(e.Extensions()["test"], ShouldEqual, "2022-11-15 10:41:25")
+		})
 	})
+}
+
+func TestUnixTimeFormatAction(t *testing.T) {
 	Convey("test format unix time", t, func() {
-		a, err := NewAction([]interface{}{newFormatUnixTimeAction().Name(), "$.data.time", "yyyy-mm-ddTHH:MM:SSZ"})
-		So(err, ShouldBeNil)
-		ceCtx := &context.EventContext{
-			Event: newEvent(),
-			Data:  map[string]interface{}{"time": float64(1668498285)},
-		}
-		err = a.Execute(ceCtx)
-		So(err, ShouldBeNil)
-		So(ceCtx.Data.(map[string]interface{})["time"], ShouldEqual, "2022-11-15T07:44:45Z")
+		Convey("test with default time zone", func() {
+			a, err := NewAction([]interface{}{newUnixTimeFormatAction().Name(), "$.data.time", "Y-m-d H:i:s"})
+			So(err, ShouldBeNil)
+			ceCtx := &context.EventContext{
+				Event: newEvent(),
+				Data:  map[string]interface{}{"time": float64(1668498285)},
+			}
+			err = a.Execute(ceCtx)
+			So(err, ShouldBeNil)
+			So(ceCtx.Data.(map[string]interface{})["time"], ShouldEqual, "2022-11-15 07:44:45")
+		})
+		Convey("test with time zone", func() {
+			a, err := NewAction([]interface{}{newUnixTimeFormatAction().Name(), "$.data.time", "Y-m-d H:i:s", "EST"})
+			So(err, ShouldBeNil)
+			ceCtx := &context.EventContext{
+				Event: newEvent(),
+				Data:  map[string]interface{}{"time": float64(1668498285)},
+			}
+			err = a.Execute(ceCtx)
+			So(err, ShouldBeNil)
+			So(ceCtx.Data.(map[string]interface{})["time"], ShouldEqual, "2022-11-15 02:44:45")
+		})
 	})
 }

--- a/internal/primitive/transform/action/time_action_test.go
+++ b/internal/primitive/transform/action/time_action_test.go
@@ -38,7 +38,6 @@ func TestDateFormatAction(t *testing.T) {
 			e.SetExtension("test", "2022-11-15T15:41:25Z")
 			a, err := NewAction([]interface{}{newDateFormatAction().Name(), "$.test", "Y-m-d H:i:s"})
 			So(err, ShouldBeNil)
-
 			err = a.Execute(&context.EventContext{
 				Event: e,
 			})
@@ -50,7 +49,6 @@ func TestDateFormatAction(t *testing.T) {
 			e.SetExtension("test", "2022-11-15T15:41:25Z")
 			a, err := NewAction([]interface{}{newDateFormatAction().Name(), "$.test", "Y-m-d H:i:s", "EST"})
 			So(err, ShouldBeNil)
-
 			err = a.Execute(&context.EventContext{
 				Event: e,
 			})

--- a/internal/primitive/transform/function/format_functions.go
+++ b/internal/primitive/transform/function/format_functions.go
@@ -15,41 +15,47 @@
 package function
 
 import (
-	"strings"
 	"time"
+
+	"github.com/linkall-labs/vanus/internal/primitive/transform/function/util"
 )
 
-// convertTimeFormat2Go convert "yyyy-mm-dd HH:MM:SS" to "2006-01-02 15:04:05".
-func convertTimeFormat2Go(format string) string {
-	v := strings.ReplaceAll(format, "yyyy", "2006")
-	v = strings.ReplaceAll(v, "mm", "01")
-	v = strings.ReplaceAll(v, "dd", "02")
-	v = strings.ReplaceAll(v, "HH", "15")
-	v = strings.ReplaceAll(v, "MM", "04")
-	v = strings.ReplaceAll(v, "SS", "05")
-	return v
-}
-
-var FormatDateFunction = function{
-	name:      "FORMAT_DATE",
-	fixedArgs: []Type{String, String, String},
+var DateFormatFunction = function{
+	name:         "DATE_FORMAT",
+	fixedArgs:    []Type{String, String},
+	variadicArgs: TypePtr(String),
 	fn: func(args []interface{}) (interface{}, error) {
-		fromFormat := convertTimeFormat2Go(args[1].(string))
-		t, err := time.Parse(fromFormat, args[0].(string))
+		t, err := time.ParseInLocation(time.RFC3339, args[0].(string), time.UTC)
 		if err != nil {
 			return nil, err
 		}
-		toFormat := convertTimeFormat2Go(args[2].(string))
-		return t.Format(toFormat), nil
+		loc := time.UTC
+		if len(args) > 2 && args[2].(string) != "" {
+			loc, err = time.LoadLocation(args[2].(string))
+			if err != nil {
+				return nil, err
+			}
+		}
+		format := util.ConvertFormat2Go(args[1].(string))
+		return t.In(loc).Format(format), nil
 	},
 }
 
-var FormatUnixTimeFunction = function{
-	name:      "FORMAT_UNIX_TIME",
-	fixedArgs: []Type{Number, String},
+var UnixTimeFormatFunction = function{
+	name:         "UNIX_TIME_FORMAT",
+	fixedArgs:    []Type{Number, String},
+	variadicArgs: TypePtr(String),
 	fn: func(args []interface{}) (interface{}, error) {
 		t := time.Unix(int64(args[0].(float64)), 0)
-		toFormat := convertTimeFormat2Go(args[1].(string))
-		return t.UTC().Format(toFormat), nil
+		loc := time.UTC
+		if len(args) > 2 && args[2].(string) != "" {
+			var err error
+			loc, err = time.LoadLocation(args[2].(string))
+			if err != nil {
+				return nil, err
+			}
+		}
+		format := util.ConvertFormat2Go(args[1].(string))
+		return t.In(loc).Format(format), nil
 	},
 }

--- a/internal/primitive/transform/function/util/time.go
+++ b/internal/primitive/transform/function/util/time.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "bytes"
+
+var formats = map[byte]string{
+	'd': "02",   // Day:    Day of the month, 2 digits with leading zeros. Eg: 01 to 31.
+	'm': "01",   // Month:  Numeric representation of a month, with leading zeros. Eg: 01 through 12.
+	'Y': "2006", // Year:   A full numeric representation of a year, 4 digits. Eg: 1999 or 2003.
+	'y': "06",   // Year:   A two digit representation of a year. Eg: 99 or 03.
+	'h': "03",   // Time:   12-hour format of an hour with leading zeros. Eg: 01 through 12.
+	'H': "15",   // Time:   24-hour format of an hour with leading zeros. Eg: 00 through 23.
+	'i': "04",   // Time:   Minutes with leading zeros. Eg: 00 to 59.
+	's': "05",   // Time:   Seconds with leading zeros. Eg: 00 through 59.
+}
+
+// ConvertFormat2Go converts format to layout.
+func ConvertFormat2Go(format string) string {
+	buffer := bytes.NewBuffer(nil)
+	for i := 0; i < len(format); i++ {
+		if layout, ok := formats[format[i]]; ok {
+			buffer.WriteString(layout)
+		} else {
+			switch format[i] {
+			case '\\': // raw output, no parse
+				buffer.WriteByte(format[i+1])
+				i++
+				continue
+			default:
+				buffer.WriteByte(format[i])
+			}
+		}
+	}
+	return buffer.String()
+}

--- a/internal/primitive/transform/function/util/time_test.go
+++ b/internal/primitive/transform/function/util/time_test.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestFormat2layout(t *testing.T) {
+	Convey("test format 2 layout", t, func() {
+		format := "Y-m-dTH:i:s"
+		layout := ConvertFormat2Go(format)
+		So(layout, ShouldEqual, "2006-01-02T15:04:05")
+	})
+}


### PR DESCRIPTION
Signed-off-by: delu <delu.xu@linkall.com>

<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/linkall-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

Issue Number: close #xxx

### Problem Summary

### What is changed and how does it work?

- change function format_date to date_format
- function date_format remove fromFormat param which use default format RFC3339, and add param timeZone which default is UTC
- change function format_unix_time to unix_time_format
- unix_time_format add param timeZone which default is UTC
- change date format  from YYYY-mm-dd HH:MM:SS to Y-m-d H:i:s

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
