### PR TITLE
fix: the route cannot be updated after the controller leader switched

### DIFF
--- a/pkg/cluster/raw_client/conn.go
+++ b/pkg/cluster/raw_client/conn.go
@@ -16,11 +16,9 @@ package raw_client
 
 import (
 	"context"
-	stderr "errors"
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -190,7 +188,7 @@ func isNeedRetry(err error) bool {
 	if err == nil {
 		return false
 	}
-	if stderr.Is(err, errors.ErrNoControllerLeader) {
+	if errors.Is(err, errors.ErrNotLeader) {
 		return true
 	}
 	sts := status.Convert(err)
@@ -200,20 +198,6 @@ func isNeedRetry(err error) bool {
 	if sts.Code() == codes.Unavailable {
 		return true
 	}
-
-	if strings.Contains(sts.Message(), "NOT_LEADER") {
-		return true
-	}
-	//errType, ok := errpb.Convert(sts.Message())
-	//if !ok {
-	//	return false
-	//}
-	//if errType.Code == errpb.ErrorCode_NOT_LEADER {
-	//	log.Info(nil, "ErrorCode_NOT_LEADER", map[string]interface{}{
-	//		log.KeyError: err,
-	//	})
-	//	return true
-	//}
 	return false
 }
 


### PR DESCRIPTION
Signed-off-by: jyjiangkai <jyjiangkai@163.com>

### What problem does this PR solve?
```
time="2022-12-20T15:16:32Z" level=warning msg="failed to GetAppendableSegment" error="rpc error: code = Unknown desc = {\"code\":9700,\"message\":\"i'm not leader, please connect to: vanus-controller-2.vanus-controller.vanus.svc:2048\"}" req="event_log_id:3254845456 limited:1" res="<nil>"
time="2022-12-20T15:16:32Z" level=warning msg="invoke error, try to retry" error="rpc error: code = Unknown desc = {\"code\":9700,\"message\":\"i'm not leader, please connect to: vanus-controller-2.vanus-controller.vanus.svc:2048\"}"
time="2022-12-20T15:16:32Z" level=warning msg="invoke error" error="rpc error: code = Unknown desc = {\"code\":9700,\"message\":\"i'm not leader, please connect to: vanus-controller-2.vanus-controller.vanus.svc:2048\"}"
```

Issue Number: close #xxx

### Problem Summary

### What is changed and how does it work?

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
