### PR TITLE
fix(store): raft commit ahead of stable entries

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -287,7 +287,7 @@ func (l *raftLog) appliedTo(i uint64) {
 
 func (l *raftLog) localCommitTo(tocommit uint64) {
 	if tocommit >= l.unstable.offset {
-		tocommit = l.unstable.offset
+		tocommit = l.unstable.offset - 1
 	}
 	// never decrease commit
 	if l.localCommitted < tocommit {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

### Problem Summary

raft commit index if ahead of stable entries after #313 and #325

### What is changed and how does it work?

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
