### PR TITLE
fix: raft local commit not advance sometimes

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1157,6 +1157,8 @@ func stepLeader(r *raft, m pb.Message) error {
 			if r.maybeCommit() {
 				// TODO(james.yin): Send latest commit to follower nodes?
 				// r.bcastAppend()
+			} else {
+				r.raftLog.localCommitTo(r.raftLog.committed)
 			}
 		}
 		return nil


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

### Problem Summary

local commit of raft leader not advance sometimes after #313

### What is changed and how does it work?

### Check List

#### Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
