### PR TITLE
fix(store): recursive calls cause io worker exhaustion

### DIFF
--- a/internal/store/vsb/block_append.go
+++ b/internal/store/vsb/block_append.go
@@ -204,7 +204,7 @@ func (b *vsBlock) CommitAppend(ctx context.Context, frag block.Fragment, cb bloc
 
 		m, i := makeSnapshot(b.actx, b.indexes)
 
-		b.appendIndexEntry(ctx, i, func(n int, err error) {
+		go b.appendIndexEntry(ctx, i, func(n int, err error) {
 			defer b.wg.Done()
 			b.indexOffset = m.writeOffset
 			b.indexLength = n


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

### Problem Summary

Recursive calls cause io worker exhaustion.

### What is changed and how does it work?

Create new goroutine.

### Check List

#### Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
