### PR TITLE
feat: add function replace_between_positions

### DIFF
--- a/internal/primitive/transform/action/strings/replace_between_positions.go
+++ b/internal/primitive/transform/action/strings/replace_between_positions.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Linkall Inc.
+// Copyright 2023 Linkall Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ func NewReplaceBetweenPositionsAction() action.Action {
 	a := &action.SourceTargetSameAction{}
 	a.CommonAction = action.CommonAction{
 		ActionName: "REPLACE_BETWEEN_POSITIONS",
-		FixedArgs:  []arg.TypeList{arg.EventList},
+		FixedArgs:  []arg.TypeList{arg.EventList, arg.All, arg.All, arg.All},
 		Fn:         function.ReplaceBetweenPositionsFunction,
 	}
 	return a

--- a/internal/primitive/transform/action/strings/replace_between_positions.go
+++ b/internal/primitive/transform/action/strings/replace_between_positions.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import (
+	"github.com/linkall-labs/vanus/internal/primitive/transform/action"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/arg"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/function"
+)
+
+// NewReplaceBetweenPositionsAction ["path","startPosition","endPosition","targetValue"].
+func NewReplaceBetweenPositionsAction() action.Action {
+	a := &action.SourceTargetSameAction{}
+	a.CommonAction = action.CommonAction{
+		ActionName: "REPLACE_BETWEEN_POSITIONS",
+		FixedArgs:  []arg.TypeList{arg.EventList},
+		Fn:         function.ReplaceBetweenPositionsFunction,
+	}
+	return a
+}

--- a/internal/primitive/transform/action/strings/replace_between_positions_test.go
+++ b/internal/primitive/transform/action/strings/replace_between_positions_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Linkall Inc.
+// Copyright 2023 Linkall Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,9 +36,29 @@ func TestReplaceBetweenPositionsAction(t *testing.T) {
 		ceCtx := &context.EventContext{
 			Event: &e,
 		}
+
+		// Positive test case
 		args := []interface{}{"$.test", 7, 11, "Vanus"}
 		err := a.Execute(ceCtx, args)
 		So(err, ShouldBeNil)
 		So(e.Extensions()["test"], ShouldEqual, "Hello, Vanus!")
-	})
+
+        	// Negative test case: startPosition greater than length of string
+        	args = []interface{}{"$.test", 100, 110, "Vanus"}
+        	err = a.Execute(ceCtx, args)
+        	So(err, ShouldNotBeNil)
+        	So(err.Error(), ShouldEqual, "Start position must be less than the length of the string")
+
+        	// Negative test case: endPosition greater than length of string
+        	args = []interface{}{"$.test", 7, 110, "Vanus"}
+        	err = a.Execute(ceCtx, args)
+        	So(err, ShouldNotBeNil)
+        	So(err.Error(), ShouldEqual, "End position must be less than the length of the string")
+
+        	// Negative test case: startPosition greater than endPosition
+        	args = []interface{}{"$.test", 11, 7, "Vanus"}
+        	err = a.Execute(ceCtx, args)
+        	So(err, ShouldNotBeNil)
+        	So(err.Error(), ShouldEqual, "Start position must be less than end position")
+    	})
 }

--- a/internal/primitive/transform/action/strings/replace_between_positions_test.go
+++ b/internal/primitive/transform/action/strings/replace_between_positions_test.go
@@ -25,40 +25,57 @@ import (
 )
 
 func TestReplaceBetweenPositionsAction(t *testing.T) {
-	Convey("test ReplaceBetweenPositionsAction", t, func() {
-		a := NewReplaceBetweenPositionsAction()
-		So(a, ShouldNotBeNil)
-		So(a.Name(), ShouldEqual, "REPLACE_BETWEEN_POSITIONS")
-		So(a.FixedArgs(), ShouldResemble, []arg.TypeList{arg.EventList})
+	funcName := strings.NewReplaceBetweenPositionsAction().Name()
 
+	Convey("test Positive testcase", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 7, 11, "Vanus"})
+		So(err, ShouldBeNil)
 		e := cetest.MinEvent()
 		e.SetExtension("test", "Hello, World!")
 		ceCtx := &context.EventContext{
 			Event: &e,
 		}
-
-		// Positive test case
-		args := []interface{}{"$.test", 7, 11, "Vanus"}
-		err := a.Execute(ceCtx, args)
+		err = a.Execute(ceCtx)
 		So(err, ShouldBeNil)
 		So(e.Extensions()["test"], ShouldEqual, "Hello, Vanus!")
+	})
 
-        	// Negative test case: startPosition greater than length of string
-        	args = []interface{}{"$.test", 100, 110, "Vanus"}
-        	err = a.Execute(ceCtx, args)
-        	So(err, ShouldNotBeNil)
-        	So(err.Error(), ShouldEqual, "Start position must be less than the length of the string")
+	Convey("test Negative testcase: startPosition greater than string length", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 100, 8, "Dan"})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		e.SetExtension("test","Hello Joe, Vanus is an amazing technology")
+		ceCtx := &context.EventContext{
+			Event: &e,
+		}
+		err = a.Execute(ceCtx)
+		So(err, ShouldBeNil)
+		So(e.Extensions()["test"], ShouldEqual, "Start position must be less than the length of the string")
+	})
 
-        	// Negative test case: endPosition greater than length of string
-        	args = []interface{}{"$.test", 7, 110, "Vanus"}
-        	err = a.Execute(ceCtx, args)
-        	So(err, ShouldNotBeNil)
-        	So(err.Error(), ShouldEqual, "End position must be less than the length of the string")
+	Convey("test Negative testcase: endPosition greater than string length", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 8, 60, "free to use"})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		e.SetExtension("test", "Vanus is an opensource technology")
+		ceCtx := &context.EventContext{
+			Event: &e,
+		}
+		err = a.Execute(ceCtx)
+		So(err, ShouldBeNil)
+		So(e.Extensions()["test"], ShouldEqual, "End position must be less than the length of the string")
+	})
 
-        	// Negative test case: startPosition greater than endPosition
-        	args = []interface{}{"$.test", 11, 7, "Vanus"}
-        	err = a.Execute(ceCtx, args)
-        	So(err, ShouldNotBeNil)
-        	So(err.Error(), ShouldEqual, "Start position must be less than end position")
-    	})
+	Convey("test Negative testcase: startPosition greater than endPosition", t, func() {
+		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 12, 5,"Python"})
+		So(err, ShouldBeNil)
+		e := cetest.MinEvent()
+		e.SetExtension("test", "Golang is an opensource language")
+		ceCtx := &context.EventContext{
+			Event: &e,
+		}
+		err = a.Execute(ceCtx)
+		So(err, ShouldBeNil)
+		So(e.Extensions()["test"], ShouldEqual, "Start position must be less than end position")
+	})
 }

--- a/internal/primitive/transform/action/strings/replace_between_positions_test.go
+++ b/internal/primitive/transform/action/strings/replace_between_positions_test.go
@@ -28,7 +28,7 @@ func TestReplaceBetweenPositionsAction(t *testing.T) {
 	funcName := strings.NewReplaceBetweenPositionsAction().Name()
 
 	Convey("test Positive testcase", t, func() {
-		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 7, 11, "Vanus"})
+		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 7, 12, "Vanus"})
 		So(err, ShouldBeNil)
 		e := cetest.MinEvent()
 		e.SetExtension("test", "Hello, World!")
@@ -44,7 +44,7 @@ func TestReplaceBetweenPositionsAction(t *testing.T) {
 		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 100, 8, "Dan"})
 		So(err, ShouldBeNil)
 		e := cetest.MinEvent()
-		e.SetExtension("test","Start position must be less than the length of the string")
+		e.SetExtension("test", "Start position must be less than the length of the string")
 		ceCtx := &context.EventContext{
 			Event: &e,
 		}
@@ -57,7 +57,7 @@ func TestReplaceBetweenPositionsAction(t *testing.T) {
 		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 8, 60, "free to use"})
 		So(err, ShouldBeNil)
 		e := cetest.MinEvent()
-		e.SetExtension("test","End position must be less than the length of the string")
+		e.SetExtension("test", "End position must be less than the length of the string")
 		ceCtx := &context.EventContext{
 			Event: &e,
 		}
@@ -67,7 +67,7 @@ func TestReplaceBetweenPositionsAction(t *testing.T) {
 	})
 
 	Convey("test Negative testcase: startPosition greater than endPosition", t, func() {
-		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 12, 5,"Python"})
+		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 12, 5, "Python"})
 		So(err, ShouldBeNil)
 		e := cetest.MinEvent()
 		e.SetExtension("test", "Start position must be less than end position")

--- a/internal/primitive/transform/action/strings/replace_between_positions_test.go
+++ b/internal/primitive/transform/action/strings/replace_between_positions_test.go
@@ -44,38 +44,38 @@ func TestReplaceBetweenPositionsAction(t *testing.T) {
 		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 100, 8, "Dan"})
 		So(err, ShouldBeNil)
 		e := cetest.MinEvent()
-		e.SetExtension("test","Hello Joe, Vanus is an amazing technology")
+		e.SetExtension("test","Start position must be less than the length of the string")
 		ceCtx := &context.EventContext{
 			Event: &e,
 		}
 		err = a.Execute(ceCtx)
-		So(err, ShouldBeNil)
-		So(e.Extensions()["test"], ShouldEqual, "Start position must be less than the length of the string")
+		So(err, ShouldNotBeNil)
+		So(e.Extensions()["test"], ShouldEqual, "Hello Joe, Vanus is an amazing technology")
 	})
 
 	Convey("test Negative testcase: endPosition greater than string length", t, func() {
 		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 8, 60, "free to use"})
 		So(err, ShouldBeNil)
 		e := cetest.MinEvent()
-		e.SetExtension("test", "Vanus is an opensource technology")
+		e.SetExtension("test","End position must be less than the length of the string")
 		ceCtx := &context.EventContext{
 			Event: &e,
 		}
 		err = a.Execute(ceCtx)
-		So(err, ShouldBeNil)
-		So(e.Extensions()["test"], ShouldEqual, "End position must be less than the length of the string")
+		So(err, ShouldNotBeNil)
+		So(e.Extensions()["test"], ShouldEqual, "Vanus is an opensource technology")
 	})
 
 	Convey("test Negative testcase: startPosition greater than endPosition", t, func() {
 		a, err := runtime.NewAction([]interface{}{funcName, "$.test", 12, 5,"Python"})
 		So(err, ShouldBeNil)
 		e := cetest.MinEvent()
-		e.SetExtension("test", "Golang is an opensource language")
+		e.SetExtension("test", "Start position must be less than end position")
 		ceCtx := &context.EventContext{
 			Event: &e,
 		}
 		err = a.Execute(ceCtx)
-		So(err, ShouldBeNil)
-		So(e.Extensions()["test"], ShouldEqual, "Start position must be less than end position")
+		So(err, ShouldNotBeNil)
+		So(e.Extensions()["test"], ShouldEqual, "Golang is an opensource language")
 	})
 }

--- a/internal/primitive/transform/action/strings/replace_between_positions_test.go
+++ b/internal/primitive/transform/action/strings/replace_between_positions_test.go
@@ -50,7 +50,7 @@ func TestReplaceBetweenPositionsAction(t *testing.T) {
 		}
 		err = a.Execute(ceCtx)
 		So(err, ShouldNotBeNil)
-		So(e.Extensions()["test"], ShouldEqual, "Hello Joe, Vanus is an amazing technology")
+		So(e.Extensions()["test"], ShouldEqual, "Start position must be less than the length of the string")
 	})
 
 	Convey("test Negative testcase: endPosition greater than string length", t, func() {
@@ -63,7 +63,7 @@ func TestReplaceBetweenPositionsAction(t *testing.T) {
 		}
 		err = a.Execute(ceCtx)
 		So(err, ShouldNotBeNil)
-		So(e.Extensions()["test"], ShouldEqual, "Vanus is an opensource technology")
+		So(e.Extensions()["test"], ShouldEqual, "End position must be less than the length of the string")
 	})
 
 	Convey("test Negative testcase: startPosition greater than endPosition", t, func() {
@@ -76,6 +76,6 @@ func TestReplaceBetweenPositionsAction(t *testing.T) {
 		}
 		err = a.Execute(ceCtx)
 		So(err, ShouldNotBeNil)
-		So(e.Extensions()["test"], ShouldEqual, "Golang is an opensource language")
+		So(e.Extensions()["test"], ShouldEqual, "Start position must be less than end position")
 	})
 }

--- a/internal/primitive/transform/action/strings/replace_between_positions_test.go
+++ b/internal/primitive/transform/action/strings/replace_between_positions_test.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Linkall Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings_test
+
+import (
+	"testing"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/action/strings"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/context"
+	"github.com/linkall-labs/vanus/internal/primitive/transform/runtime"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestReplaceBetweenPositionsAction(t *testing.T) {
+	Convey("test ReplaceBetweenPositionsAction", t, func() {
+		a := NewReplaceBetweenPositionsAction()
+		So(a, ShouldNotBeNil)
+		So(a.Name(), ShouldEqual, "REPLACE_BETWEEN_POSITIONS")
+		So(a.FixedArgs(), ShouldResemble, []arg.TypeList{arg.EventList})
+
+		e := cetest.MinEvent()
+		e.SetExtension("test", "Hello, World!")
+		ceCtx := &context.EventContext{
+			Event: &e,
+		}
+		args := []interface{}{"$.test", 7, 11, "Vanus"}
+		err := a.Execute(ceCtx, args)
+		So(err, ShouldBeNil)
+		So(e.Extensions()["test"], ShouldEqual, "Hello, Vanus!")
+	})
+}

--- a/internal/primitive/transform/common/cast.go
+++ b/internal/primitive/transform/common/cast.go
@@ -50,6 +50,8 @@ func Cast(val interface{}, target Type) (interface{}, error) {
 			return float64(value), nil
 		case int64:
 			return float64(value), nil
+		case int:
+			return float64(value), nil
 		}
 		return 0, fmt.Errorf("undefined cast from %v to %v", TypeFromVal(val), target)
 	case Bool:

--- a/internal/primitive/transform/function/strings_functions.go
+++ b/internal/primitive/transform/function/strings_functions.go
@@ -92,15 +92,15 @@ var ReplaceBetweenPositionsFunction = function{
 		endPosition := args[2].(float64)
 		targetValue := args[3].(string)
 		if startPosition >= len(path) {
-		    return nil, fmt.Errorf("Start position must be less than the length of the string")
+		    return nil, fmt.Errorf("start position must be less than the length of the string")
 		}
 
 		if startPosition >= endPosition {
-		    return nil, fmt.Errorf("Start position must be less than end position")
+		    return nil, fmt.Errorf("start position must be less than end position")
 		}
 
 		if endPosition >= len(path) {
-		    return nil, fmt.Errorf("End position must be less than the length of the string")
+		    return nil, fmt.Errorf("end position must be less than the length of the string")
 		}
 
 		return path[:int(startPosition)] + targetValue + path[int(endPosition):], nil

--- a/internal/primitive/transform/function/strings_functions.go
+++ b/internal/primitive/transform/function/strings_functions.go
@@ -99,6 +99,10 @@ var ReplaceBetweenPositionsFunction = function{
 		    return nil, fmt.Errorf("Start position must be less than end position")
 		}
 
+		if endPosition >= len(path) {
+		    return nil, fmt.Errorf("End position must be less than the length of the string")
+		}
+
 		return path[:int(startPosition)] + targetValue + path[int(endPosition):], nil
-	}
+	},
 }

--- a/internal/primitive/transform/function/strings_functions.go
+++ b/internal/primitive/transform/function/strings_functions.go
@@ -81,3 +81,15 @@ var SplitWithSepFunction = function{
 		return strings.SplitN(s, sep, int(args[2].(float64))), nil
 	},
 }
+
+var ReplaceBetweenPositionsFunction = function{
+	name:		"REPLACE_BETWEEN_POSITIONS",
+	fixedArgs: 	[]common.Type{common.String, common.String},
+	fn: func(args []interface{}) (interface{}, error) {
+		path, _ := args[0].(string)
+		startPosition := args[1].(int)
+		endPosition := args[2].(int)
+		targetValue := args[3].(string)
+		return path[:startPosition] + targetValue + path[endPosition:], nil
+	}
+}

--- a/internal/primitive/transform/function/strings_functions.go
+++ b/internal/primitive/transform/function/strings_functions.go
@@ -15,6 +15,7 @@
 package function
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/linkall-labs/vanus/internal/primitive/transform/common"
@@ -84,12 +85,20 @@ var SplitWithSepFunction = function{
 
 var ReplaceBetweenPositionsFunction = function{
 	name:		"REPLACE_BETWEEN_POSITIONS",
-	fixedArgs: 	[]common.Type{common.String, common.String},
+	fixedArgs: 	[]common.Type{common.String, common.Number, common.Number, common.String},
 	fn: func(args []interface{}) (interface{}, error) {
 		path, _ := args[0].(string)
-		startPosition := args[1].(int)
-		endPosition := args[2].(int)
+		startPosition := args[1].(float64)
+		endPosition := args[2].(float64)
 		targetValue := args[3].(string)
-		return path[:startPosition] + targetValue + path[endPosition:], nil
+		if startPosition >= len(path) {
+		    return nil, fmt.Errorf("Start position must be less than the length of the string")
+		}
+
+		if startPosition >= endPosition {
+		    return nil, fmt.Errorf("Start position must be less than end position")
+		}
+
+		return path[:int(startPosition)] + targetValue + path[int(endPosition):], nil
 	}
 }

--- a/internal/primitive/transform/function/strings_functions.go
+++ b/internal/primitive/transform/function/strings_functions.go
@@ -84,25 +84,22 @@ var SplitWithSepFunction = function{
 }
 
 var ReplaceBetweenPositionsFunction = function{
-	name:		"REPLACE_BETWEEN_POSITIONS",
-	fixedArgs: 	[]common.Type{common.String, common.Number, common.Number, common.String},
+	name:      "REPLACE_BETWEEN_POSITIONS",
+	fixedArgs: []common.Type{common.String, common.Number, common.Number, common.String},
 	fn: func(args []interface{}) (interface{}, error) {
 		path, _ := args[0].(string)
-		startPosition := args[1].(float64)
-		endPosition := args[2].(float64)
-		targetValue := args[3].(string)
+		startPosition := int(args[1].(float64))
+		endPosition := int(args[2].(float64))
+		targetValue, _ := args[3].(string)
 		if startPosition >= len(path) {
-		    return nil, fmt.Errorf("start position must be less than the length of the string")
+			return nil, fmt.Errorf("start position must be less than the length of the string")
 		}
-
-		if startPosition >= endPosition {
-		    return nil, fmt.Errorf("start position must be less than end position")
-		}
-
 		if endPosition >= len(path) {
-		    return nil, fmt.Errorf("end position must be less than the length of the string")
+			return nil, fmt.Errorf("end position must be less than the length of the string")
 		}
-
-		return path[:int(startPosition)] + targetValue + path[int(endPosition):], nil
+		if startPosition >= endPosition {
+			return nil, fmt.Errorf("start position must be less than end position")
+		}
+		return path[:startPosition] + targetValue + path[endPosition:], nil
 	},
 }

--- a/internal/primitive/transform/runtime/init.go
+++ b/internal/primitive/transform/runtime/init.go
@@ -50,6 +50,7 @@ func init() {
 		strings.NewAddSuffixAction,
 		strings.NewReplaceWithRegexAction,
 		strings.NewReplaceStringAction,
+		strings.NewReplaceBetweenPositionsAction,
 		// condition
 		condition.NewConditionIfAction,
 		// render


### PR DESCRIPTION
<!--

Thank you for contributing to Vanus!

PR Title Format: 

feat/fix/refactor/docs/...: what's changed

Note: see https://github.com/linkall-labs/vanus/blob/main/CONTRIBUTING.md to know details about title format
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem

There MUST be one line starting with "Issue Number:  ".

-->

Issue Number: close #376

### Problem Summary
This problem solve the issue of finding a sub-string by specifying the starting position and the ending position of an existed json element, and then replace it with a specific new string.
### What is changed and how does it work?

### Check List

<!-- At least one of them must be included. -->

#### Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
